### PR TITLE
Fixed timeline continuity.

### DIFF
--- a/src/views/index.html
+++ b/src/views/index.html
@@ -352,8 +352,10 @@
               <div class="line-dot line-dot-right"></div>
             </div>
             <div class="timeline-content" id="hh2018">
-              <h2><a href="/th/2019">TAMUhack 2019</a></h2>
-              <p class="custom-p-text">Our 5th anniversary of TAMUhack :)</p>
+              <h2><a href="/hh/2019">HowdyHack 2019</a></h2>
+              <p class="custom-p-text" dir=ltr>
+                Our fall hackathon nearly triples in size!
+              </p>
             </div>
           </div>
           <!--END Timeline Block-->
@@ -366,10 +368,8 @@
               <div class="line"></div>
             </div>
             <div class="timeline-content no-hover">
-              <h2><a href="/hh/2019">HowdyHack 2019</a></h2>
-              <p class="custom-p-text" dir=ltr>
-                Our fall hackathon nearly triples in size!
-              </p>
+              <h2><a href="/th/2019">TAMUhack 2019</a></h2>
+              <p class="custom-p-text">(: Our 5th anniversary of TAMUhack</p>
             </div>
           </div>
           <!--END Timeline Block-->


### PR DESCRIPTION
The past-iteration timeline had HowdyHack2019 and TAMUhack2019 out of order according to the order the rest of the timeline was in (HowdyHack2019 happened after TAMUhack2019, but was before it in the timeline).

I moved the smiley face to the other side of the <p> tag because the timeline-block-left class moved the smiley face to the other side of the text (ex: from <p>Our 5th anniversary of TAMUhack :)</p> to "(: Our 5th anniversary of TAMUhack").