### PR TITLE
fix: Update HowdyHack 2021 link

### DIFF
--- a/index.html
+++ b/index.html
@@ -1218,7 +1218,7 @@
             },
             {
               name: "HowdyHack 2021",
-              link: "/hh",
+              link: "/hh/2021",
               logo: "hh21",
               description: "Our first hybrid Hackathon!",
               directors: [


### PR DESCRIPTION
HowdyHack 2021 `Visit Event Page` button should direct to `/hh/2021` instead of `/hh`